### PR TITLE
Upgrade opentracing dependency

### DIFF
--- a/grpc-opentracing.gemspec
+++ b/grpc-opentracing.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'grpc'
   spec.add_dependency "multi_json"
-  spec.add_dependency 'opentracing', '~> 0.3.1'
+  spec.add_dependency 'opentracing', '~> 0.5.0'
   spec.add_dependency "method-tracer", "~> 1.1"
 
   spec.add_development_dependency "test-tracer", "~> 1.0", ">= 1.2.1"


### PR DESCRIPTION
I'm trying to add this gem to my project, but I've upgraded to opentracing 0.5.0 (released in Jan) and bundler is not letting me do it.

There doesn't seem to be any glaring change that would break the code between 0.3.1 (current version supported by this project) and latest.